### PR TITLE
Add routes configuration

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,47 @@ spring:
   application:
     name: gateway-service
 
+zuul:
+  routes:
+    login:
+      path: /login/**
+      serviceId: user-service
+      stripPrefix: false
+    users:
+      path: /users/**
+      serviceId: user-service
+    offices:
+      path: /offices/**
+      serviceId: user-service
+      stripPrefix: false
+    cars:
+      path: /cars/**
+      serviceId: user-service
+      stripPrefix: false
+    contact-info:
+      path: /contact-info/**
+      serviceId: user-service
+      stripPrefix: false
+    location:
+      path: /location/**
+      serviceId: maps-service
+      stripPrefix: false
+    route:
+      path: /route/**
+      serviceId: maps-service
+      stripPrefix: false
+    matches:
+      path: /matches/**
+      serviceId: matching-service
+    likes:
+      path: /likes/**
+      serviceId: matching-service
+      stripPrefix: false
+    dislikes:
+      path: /dislikes/**
+      serviceId: matching-service
+      stripPrefix: false
+
 eureka:
   client:
     service-url:


### PR DESCRIPTION
This adds (tentative) information to `application.yml` setting up all the routes that are listed in the API documentation. Actual implementations are dependent on the work of the individual microservices.