### PR TITLE
Stop stripping Authentication headers from incoming requests

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,9 @@ spring:
     name: gateway-service
 
 zuul:
+  sensitive-headers:
+    - Cookie
+    - Set-Cookie
   routes:
     registration-key:
       path: /registration-key/**


### PR DESCRIPTION
The JWT will be intercepted correctly by downstream services now.